### PR TITLE
Fix to cope with warnings

### DIFF
--- a/kodougu.gemspec
+++ b/kodougu.gemspec
@@ -31,8 +31,8 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "bundler", "~> 1.14"
-  spec.add_development_dependency "rake", ">= 10.0"
-  spec.add_development_dependency "test-unit", "~> 3.2.3"
+  spec.add_development_dependency "rake", "~> 12.0"
+  spec.add_development_dependency "test-unit", "~> 3.2"
 
-  spec.add_dependency "slop", "~> 4.4.3"
+  spec.add_dependency "slop", "~> 4.4"
 end


### PR DESCRIPTION
Cope with warnings generated by `gem` while building a gem.
Merge it, please.